### PR TITLE
Improve compiler error messages regarding the use of authentication

### DIFF
--- a/src/main/scala/rx/oanda/OandaEnvironment.scala
+++ b/src/main/scala/rx/oanda/OandaEnvironment.scala
@@ -41,6 +41,12 @@ object OandaEnvironment {
   sealed trait NoAuth extends Auth
   sealed trait WithAuth extends Auth
 
+  @implicitNotFound("You may only call this on an account that supports authentication.")
+  type MustHaveAuth[A] = A =:= WithAuth
+
+  @implicitNotFound("You may only call this on an account that does not use authentication.")
+  type MustNotHaveAuth[A] = A =:= NoAuth
+
   @implicitNotFound("No ConnectionPool for ${A}")
   trait ConnectionPool[A <: Auth] {
 

--- a/src/main/scala/rx/oanda/accounts/AccountClient.scala
+++ b/src/main/scala/rx/oanda/accounts/AccountClient.scala
@@ -32,25 +32,25 @@ class AccountClient[A <: OandaEnvironment.Auth](env: OandaEnvironment[A])(implic
   private[accounts] def accountRequest(accountId: Long): HttpRequest =
     HttpRequest(GET, Uri(s"/v1/accounts/$accountId"), headers = env.headers)
 
-  private[accounts] def accountsRequest(implicit ev: A =:= WithAuth): HttpRequest =
+  private[accounts] def accountsRequest(implicit ev: MustHaveAuth[A]): HttpRequest =
     HttpRequest(GET, Uri(s"/v1/accounts"), headers = env.headers)
 
-  private[accounts] def accountsRequest(username: String)(implicit ev: A =:= NoAuth): HttpRequest =
+  private[accounts] def accountsRequest(username: String)(implicit ev: MustNotHaveAuth[A]): HttpRequest =
     HttpRequest(GET, Uri(s"/v1/accounts").withRawQueryString(s"username=$username"), headers = env.headers)
 
-  private[accounts] def createAccountRequest(implicit ev: A =:= NoAuth): HttpRequest =
+  private[accounts] def createAccountRequest(implicit ev: MustNotHaveAuth[A]): HttpRequest =
     HttpRequest(POST, Uri(s"/v1/accounts"), headers = env.headers)
 
   def account(accountId: Long): Source[Account, Unit] =
     makeRequest[Account](accountRequest(accountId))
 
-  def accounts(implicit ev: A =:= WithAuth): Source[ShortAccount, Unit] =
+  def accounts(implicit ev: MustHaveAuth[A]): Source[ShortAccount, Unit] =
     makeRequest[Vector[ShortAccount]](accountsRequest).mapConcat(identity)
 
-  def accounts(username: String)(implicit ev: A =:= NoAuth): Source[ShortAccount, Unit] =
+  def accounts(username: String)(implicit ev: MustNotHaveAuth[A]): Source[ShortAccount, Unit] =
     makeRequest[Vector[ShortAccount]](accountsRequest(username)).mapConcat(identity)
 
-  def createAccount(currency: Option[String] = None)(implicit ev: A =:= NoAuth): Source[SandboxAccount, Unit] =
+  def createAccount(currency: Option[String] = None)(implicit ev: MustNotHaveAuth[A]): Source[SandboxAccount, Unit] =
     Source.empty // TODO: implement me when Sandbox API is back
 
 }


### PR DESCRIPTION
prelude:

``` scala
import akka.actor.ActorSystem
import akka.stream.ActorMaterializer
import rx.oanda._, accounts._

implicit val sys = ActorSystem()
implicit val mat = ActorMaterializer()
val sandboxClient = new AccountClient(OandaEnvironment.SandboxEnvironment)
val practiceClient = new AccountClient(OandaEnvironment.TradePracticeEnvironment("token"))
```

before:

``` scala
scala> sandboxClient.accounts
<console>:22: error: Cannot prove that rx.oanda.OandaEnvironment.NoAuth =:= rx.oanda.OandaEnvironment.WithAuth.
       sandboxClient.accounts
                     ^

scala> practiceClient.createAccountRequest
<console>:22: error: method createAccountRequest in class AccountClient cannot be accessed in rx.oanda.accounts.AccountClient[rx.oanda.OandaEnvironment.WithAuth]
       practiceClient.createAccountRequest
                      ^

scala> practiceClient.createAccount()
<console>:22: error: Cannot prove that rx.oanda.OandaEnvironment.WithAuth =:= rx.oanda.OandaEnvironment.NoAuth.
       practiceClient.createAccount()
                                   ^
```

after:

``` scala
scala> sandboxClient.accounts
<console>:22: error: You may only call this on an account that supports authentication.
       sandboxClient.accounts
                     ^

scala> practiceClient.accounts("bernd")
<console>:22: error: You may only call this on an account that does not use authentication.
       practiceClient.accounts("bernd")
                              ^

scala> practiceClient.createAccount()
<console>:22: error: You may only call this on an account that does not use authentication.
       practiceClient.createAccount()
                                   ^
```
